### PR TITLE
Added support for files with WAV (caps) suffix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@
 [metadata]
 name = wavcheck
 # NOTE: Also update main.py when updating version.
-version = 0.9.3
+version = 0.9.4
 author = Barndollar Music, Ltd.
 author_email = eric@barndollarmusic.com
 description = Check WAV files for Broadcast Wave Format issues

--- a/src/wavcheck/main.py
+++ b/src/wavcheck/main.py
@@ -14,7 +14,7 @@ from .read import read_or_prompt_framerate, read_wav_files
 from .report import report_check_results
 
 __name__ = "wavcheck"
-__version__ = "0.9.3"  # NOTE: Also update setup.cfg when updating version.
+__version__ = "0.9.4"  # NOTE: Also update setup.cfg when updating version.
 
 
 # Command-line arguments:

--- a/src/wavcheck/read.py
+++ b/src/wavcheck/read.py
@@ -112,7 +112,7 @@ def read_wav_files(ctx: Context) -> InternalState:
     result = InternalState()
     with os.scandir(ctx.dir) as entries:
         for entry in entries:
-            if entry.is_file() and str(entry.name).endswith(".wav"):
+            if entry.is_file() and (str(entry.name).endswith(".wav") or str(entry.name).endswith(".WAV")):
                 ctx.maybe_print_verbose(f"Reading {entry.name} ...")
                 p = pathlib.Path(entry.path).resolve()
                 result.wav_files[p.name] = WavFileState()

--- a/src/wavcheck/read.py
+++ b/src/wavcheck/read.py
@@ -112,7 +112,7 @@ def read_wav_files(ctx: Context) -> InternalState:
     result = InternalState()
     with os.scandir(ctx.dir) as entries:
         for entry in entries:
-            if entry.is_file() and (str(entry.name).endswith(".wav") or str(entry.name).endswith(".WAV")):
+            if entry.is_file() and str(entry.name).lower().endswith(".wav"):
                 ctx.maybe_print_verbose(f"Reading {entry.name} ...")
                 p = pathlib.Path(entry.path).resolve()
                 result.wav_files[p.name] = WavFileState()


### PR DESCRIPTION
The Zoom F3 saves filenames as CAPITALS, so wavcheck fails to find files. Easy enough to rename them, sure, but less faff if wavcheck just supports .wav or .WAV. Bumped version number as well as adding .WAV support.